### PR TITLE
Add dockerfile for openresty containing vue build process

### DIFF
--- a/Dockerfile.openresty
+++ b/Dockerfile.openresty
@@ -1,0 +1,17 @@
+ARG BASEIMG="openresty/openresty:alpine"
+ARG BUILDIMG="node:10.15.0-alpine"
+FROM $BUILDIMG as builder
+
+COPY . /project/
+
+RUN cd /project/ui/ && \
+    npm install && \
+    npm run build
+
+FROM $BASEIMG
+LABEL maintainer="Nate Catelli <ncatelli@packetfire.org>" \
+      description="Container for paste-click openresty"
+
+ENV APP_NAME=paste.click
+
+COPY --from=builder /project/ui/dist/* /www/${APP_NAME}/vue/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,10 @@
 version: '3.1'
 services:
   frontend:
-    image: openresty/openresty:alpine
+    image: packetfire/openresty-pasteclick
+    build:
+      context: ./
+      dockerfile: Dockerfile.openresty
     ports:
       - 8080:80
       - 8443:443


### PR DESCRIPTION
# Introduction
This PR creates a separate Dockerfile for the openresty frontend that will compile and generate the Vue app assets and store them in the produced image. The assets can be served by NGINX.

Follow-up PRs:
- Add routes to NGINX to serve the vue app (possibly under a different URL scheme)

# Review
- [x] Tested
---
- [x] Ready to Review
- [x] Ready to Merge
