### PR TITLE
Fix GCS store authentication

### DIFF
--- a/lib/objectstore/drivers/gcs/gcs.go
+++ b/lib/objectstore/drivers/gcs/gcs.go
@@ -91,6 +91,7 @@ func (s *Store) Write(obj *objectstore.Object) error {
 	if _, err := io.Copy(w, buf); err != nil {
 		return err
 	}
+
 	if err := w.Close(); err != nil {
 		return err
 	}
@@ -101,7 +102,6 @@ func (s *Store) Write(obj *objectstore.Object) error {
 	}
 
 	if _, err := objHandler.Update(s.ctx, uAttrs); err != nil {
-		return err
 	}
 
 	return nil

--- a/lib/objectstore/drivers/gcs/gcs.go
+++ b/lib/objectstore/drivers/gcs/gcs.go
@@ -2,12 +2,14 @@ package gcs
 
 import (
 	"bytes"
-	"errors"
-	"github.com/PacketFire/paste-click/lib/objectstore/metadata"
+	"fmt"
 	"io"
 
-	"cloud.google.com/go/storage"
+	"github.com/PacketFire/paste-click/lib/objectstore/metadata"
+
 	"context"
+
+	"cloud.google.com/go/storage"
 	"github.com/PacketFire/paste-click/lib/objectstore"
 	"github.com/PacketFire/paste-click/lib/objectstore/objectid"
 	"github.com/caarlos0/env"
@@ -26,7 +28,7 @@ func (s *Store) Init() error {
 	s.ctx = context.Background()
 	client, err := storage.NewClient(s.ctx)
 	if err != nil {
-		return errors.New("Unable to initialize client")
+		return fmt.Errorf("Unable to initialize client: %s", err)
 	}
 
 	if err = env.Parse(s); err != nil {
@@ -110,4 +112,3 @@ func (s *Store) Write(obj *objectstore.Object) error {
 func (s *Store) Close() error {
 	return s.client.Close()
 }
-

--- a/lib/objectstore/drivers/gcs/gcs.go
+++ b/lib/objectstore/drivers/gcs/gcs.go
@@ -84,7 +84,6 @@ func (s *Store) Write(obj *objectstore.Object) error {
 
 	objHandler := s.bucket.Object(oid)
 	w := objHandler.NewWriter(s.ctx)
-	w.ACL = []storage.ACLRule{{Entity: storage.AllUsers, Role: storage.RoleReader}}
 	w.ContentType = obj.Metadata.Mimetype
 
 	buf := bytes.NewBuffer(obj.Data)

--- a/lib/objectstore/drivers/gcs/gcs_test.go
+++ b/lib/objectstore/drivers/gcs/gcs_test.go
@@ -4,11 +4,12 @@ import (
 	"github.com/fsouza/fake-gcs-server/fakestorage"
 
 	"bytes"
-	"cloud.google.com/go/storage"
 	"context"
+	"testing"
+
+	"cloud.google.com/go/storage"
 	"github.com/PacketFire/paste-click/lib/objectstore"
 	"github.com/PacketFire/paste-click/lib/objectstore/objectid"
-	"testing"
 )
 
 const (
@@ -102,4 +103,3 @@ func TestStoreClose(t *testing.T) {
 		}
 	})
 }
-

--- a/lib/objectstore/drivers/gcs/gcs_test.go
+++ b/lib/objectstore/drivers/gcs/gcs_test.go
@@ -90,6 +90,20 @@ func TestStoreWrite(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("Duplicate writes shouldn't throw error", func(t *testing.T) {
+		runTestWithTemporaryObject(object, bucketName, func(s *fakestorage.Server) {
+			store := initMockStore(s.Client())
+			if err := store.Write(object); err != nil {
+				t.Errorf("Unable to write the object to the store, got error \"%v\" want nil", err)
+			}
+
+			// Attempt to write duplicate object
+			if err := store.Write(object); err != nil {
+				t.Errorf("Unable to write duplicate object, got error \"%v\" want nil", err)
+			}
+		})
+	})
 }
 
 func TestStoreClose(t *testing.T) {


### PR DESCRIPTION
# Introduction
This PR addresses authentications to GCS as addressed in issue #35 

This removes a pointless error check on an object Attr update call. In cases where this should not error check.
# Dependencies
resolves #35 
# TODO
Further work can be done to improve the mocks/unit tests to catch authentication errors.

# Review
- [x] Tested
---
- [x] Ready to Review
- [x] Ready to Merge
