### PR TITLE
Fixes publishing issues with GCS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV APP_NAME=paste-click
 
 RUN addgroup ${SERVICE_USER} && \
     adduser -D -G ${SERVICE_USER} ${SERVICE_USER} && \
-    apk add --no-cache libmagic
+    apk add --no-cache libmagic ca-certificates
 
 COPY --from=builder /${APP_NAME} /opt/${APP_NAME}/bin/
 

--- a/lib/objectstore/drivers/fs/filestore_test.go
+++ b/lib/objectstore/drivers/fs/filestore_test.go
@@ -80,7 +80,7 @@ func TestGetExtension(t *testing.T) {
 	store := initializeStoreForTesting()
 
 	t.Run("Validate that a valid mimetype returns the expected string.", func(t *testing.T) {
-		if extension := store.getExtensionFromMimetype(`text/plain`); extension != `.asc` {
+		if extension := store.getExtensionFromMimetype(`text/plain`); !(extension == `.asc` || extension == `.txt`) {
 			t.Errorf("Extension didn't match mimetype, expected .asc got %s", extension)
 		}
 	})

--- a/lib/objectstore/drivers/gcs/gcs_test.go
+++ b/lib/objectstore/drivers/gcs/gcs_test.go
@@ -34,7 +34,6 @@ func initMockStore(c *storage.Client) *Store {
 	return &Store{
 		BucketName: bucketName,
 		client:     c,
-		bucket:     c.Bucket(bucketName),
 		ctx:        context.Background(),
 	}
 }


### PR DESCRIPTION
# Introduction
This addresses an issue with writing to GCS that looks to have stemmed from a missing `ca-certificates` package per the following log.

```
backend_1   | Post https://www.googleapis.com/upload/storage/v1/b/test-paste-click/o?alt=json&prettyPrint=false&projection=full&uploadType=multipart: Post https://accounts.google.com/o/oauth2/token: x509: certificate signed by unknown authority
```

After adding the `ca-certificates` package I then retested by locally running the image pointed at our test bucket with our service credentials and was able to validate uploads worked.

```
echo "HELLO" | curl -sD - 'http://localhost:8001/' --data-binary @- -H 'Host: paste-click'
HTTP/1.1 200 OK
Date: Tue, 19 Feb 2019 02:36:32 GMT
Content-Length: 52
Content-Type: text/plain; charset=utf-8

http://paste-click/0084467710d2fc9d8a306e14efbe6d0f
```

```
gsutil list gs://test-paste-click/
gs://test-paste-click/0084467710d2fc9d8a306e14efbe6d0f
```

```
Attaching to paste-click_backend_1, paste-click_frontend_1
backend_1   | 2019/02/19 02:36:05 Starting server on :8001
backend_1   | 172.21.0.1 - - [19/Feb/2019:02:36:31 +0000] "POST / HTTP/1.1" 200 52
backend_1   | 172.21.0.1 - - [19/Feb/2019:02:37:04 +0000] "POST / HTTP/1.1" 200 52
backend_1   | 172.21.0.1 - - [19/Feb/2019:02:37:06 +0000] "POST / HTTP/1.1" 200 52
```

# Dependencies
resolves #35 
# TODO

# Review
- [x] Tested
---
- [x] Ready to Review
- [x] Ready to Merge
