### PR TITLE
return cdn url

### DIFF
--- a/handlers/upload/handler.go
+++ b/handlers/upload/handler.go
@@ -54,7 +54,7 @@ func (uh *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Unable to save object", http.StatusInternalServerError)
 	}
 
-	fileURL := strings.Join([]string{scheme, "://", r.Host, r.RequestURI, id, "\n"}, "")
+	fileURL := strings.Join([]string{scheme, "://", "cdn.", r.Host, r.RequestURI, id, "\n"}, "")
 	w.Write([]byte(fileURL))
 }
 


### PR DESCRIPTION

# Introduction

Since gcp bandwidth is expensive, and cdn bandwidth is not, use the cdn for all urls.
This is a stop gap as there is probably a better way to set this, such as an envvar for the host.

# Dependencies

# TODO

Rework to make this configurable without code changes.

# Review
- [ ] Tested
---
- [ ] Ready to Review
- [ ] Ready to Merge
