### PR TITLE
Configurable site names

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,20 @@ Paste.Click
 
 [![Build Status](https://travis-ci.org/PacketFire/paste-click.svg?branch=master)](https://travis-ci.org/PacketFire/paste-click)
 
+<!-- TOC -->
+
+- [General](#general)
+- [Building](#building)
+    - [Dependencies](#dependencies)
+    - [Docker](#docker)
+    - [Locally](#locally)
+- [Testing](#testing)
+- [Running](#running)
+    - [Docker-Compose](#docker-compose)
+- [Configuration](#configuration)
+
+<!-- /TOC -->
+
 ## General
 Paste-click is meant to serve as an online clipboard and provides easy interaction with files via curl.
 
@@ -82,13 +96,16 @@ Configuration parameters are provided via environment variables. Currently the f
 
   The bind address for the service
 
+- SITE_NAME: 'paste.click'
+  
+  A configuration setting representing the returned domain name in all upload calls.
 - LOGGING: 'true'
 
   A boolean value determining whether to enable logging of requests to stdout.
 
 - STORAGE_DRIVER: 'fs'
 
-  The backend storage driver to use. Currently there are only two, mock and fs.
+  The backend storage driver to use. Currently these options are mock, fs and gcs.
 - STORE_FS_BASE_PATH: "/www/paste.click/"
 
   The base path of the to store files under. This should always point to the document root of openresty.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - 8080:80
       - 8443:443
     volumes:
-      - content:/www/paste.click/objects/
       - proxy_cache:/data/nginx/cache
       - ./resty/ssl:/etc/ssl/nginx:ro
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       ADDR: ':8001'
       STORAGE_DRIVER: 'fs'
       STORE_FS_BASE_PATH: "/www/paste.click/objects/"
+      SITE_NAME: "localhost:8080"
     ports:
       - 8001:8001
     volumes:

--- a/handlers/upload/handler.go
+++ b/handlers/upload/handler.go
@@ -1,10 +1,10 @@
 package upload
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
-	"strings"
 
 	"github.com/PacketFire/paste-click/lib/objectstore"
 	"github.com/rakyll/magicmime"
@@ -14,13 +14,15 @@ import (
 // storage driver.
 type Handler struct {
 	StorageDriver objectstore.ObjectStore
+	siteName      string
 }
 
 // New instantiates a new upload Handler.
-func New(store objectstore.ObjectStore) *Handler {
+func New(siteName string, store objectstore.ObjectStore) *Handler {
 	store.Init()
 	return &Handler{
 		StorageDriver: store,
+		siteName:      siteName,
 	}
 }
 
@@ -54,7 +56,7 @@ func (uh *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Unable to save object", http.StatusInternalServerError)
 	}
 
-	fileURL := strings.Join([]string{scheme, "://", r.Host, r.RequestURI, id, "\n"}, "")
+	fileURL := fmt.Sprintf("%s://%s%s%s\n", scheme, uh.siteName, r.RequestURI, id)
 	w.Write([]byte(fileURL))
 }
 

--- a/handlers/upload/handler_test.go
+++ b/handlers/upload/handler_test.go
@@ -41,8 +41,9 @@ func handlerTest(method, path string, reqBody io.Reader, respCode int, respBody 
 }
 
 func TestBuiltInRoutes(t *testing.T) {
+	siteName := `paste.click`
 	store := &mock.Store{}
-	uh := New(store)
+	uh := New(siteName, store)
 	t.Run("Upload handler returns the correct response", func(t *testing.T) {
 		err := handlerTest("POST", "/", strings.NewReader(`helloworld`), http.StatusOK, `helloworld`, uh.ServeHTTP)
 		if err != nil {

--- a/lib/config/service/config.go
+++ b/lib/config/service/config.go
@@ -10,7 +10,7 @@ type Config struct {
 	Addr          string `env:"ADDR" envDefault:":8001"`
 	Logging       bool   `env:"LOGGING" envDefault:"true"`
 	StorageDriver string `env:"STORAGE_DRIVER" envDefault:"fs"`
-	SiteName      string `env:"SiteName" envDefault:"paste.click"`
+	SiteName      string `env:"SITE_NAME" envDefault:"paste.click"`
 }
 
 // New instantiates a new Config and attempts to parse parameters from

--- a/lib/config/service/config.go
+++ b/lib/config/service/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	Addr          string `env:"ADDR" envDefault:":8001"`
 	Logging       bool   `env:"LOGGING" envDefault:"true"`
 	StorageDriver string `env:"STORAGE_DRIVER" envDefault:"fs"`
+	SiteName      string `env:"SiteName" envDefault:"paste.click"`
 }
 
 // New instantiates a new Config and attempts to parse parameters from

--- a/lib/config/service/config_test.go
+++ b/lib/config/service/config_test.go
@@ -11,6 +11,7 @@ var (
 		Addr:          ":8080",
 		Logging:       true,
 		StorageDriver: "fs",
+		SiteName:      "paste.click",
 	}
 )
 

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func main() {
 	defer s.Close()
 
 	// Setup Upload handling
-	uh := upload.New(s)
+	uh := upload.New(c.SiteName, s)
 	mux.Handle(`/`, uh).Methods("POST")
 
 	// Setup read handling
@@ -64,4 +64,3 @@ func main() {
 		log.Fatalf("Error in ListenAndServe: %s", err)
 	}
 }
-


### PR DESCRIPTION
# Introduction
This PR introduces configurable site names. This adds a new configurable ENV var `SITE_NAME` that allows the response URL to upload requests to be explicitly set. When this isn't set, it defaults back to paste.click. I've included an example below using the new setting in docker-compose to `SITE_NAME='localhost:8080'`

```
echo 'hello' | curl -sD - 'http://localhost:8080/' -H 'Host: paste.click' --data-binary @-
HTTP/1.1 200 OK
Server: openresty/1.13.6.2
Date: Wed, 20 Feb 2019 03:26:30 GMT
Content-Type: text/plain; charset=utf-8
Content-Length: 55
Connection: keep-alive
Content-Disposition: filename=""
Access-Control-Allow-Origin: *

http://localhost:8080/b1946ac92492d2347c6235b4d2611184
```
# Dependencies
resolves #31 
# TODO

# Review
- [x] Tested
---
- [x] Ready to Review
- [ ] Ready to Merge
