### PR TITLE
Update text/html to -> text/plain

### DIFF
--- a/handlers/read/handler.go
+++ b/handlers/read/handler.go
@@ -1,10 +1,11 @@
 package read
 
 import (
+	"net/http"
+
 	"github.com/PacketFire/paste-click/lib/objectstore"
 	"github.com/PacketFire/paste-click/lib/objectstore/objectid"
 	"github.com/gorilla/mux"
-	"net/http"
 )
 
 // Handler stores all required context for handing off requests to a
@@ -31,6 +32,11 @@ func (uh *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.WriteHeader(http.StatusNotFound)
 		return
+	}
+
+	// DEVNOTE NC hotfix for #56
+	if object.Metadata.Mimetype == "text/html" {
+		object.Metadata.Mimetype = "text/plain"
 	}
 
 	// Set paste-click metadata headers.

--- a/handlers/read/handler_test.go
+++ b/handlers/read/handler_test.go
@@ -2,11 +2,12 @@ package read
 
 import (
 	"fmt"
-	"github.com/gorilla/mux"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/gorilla/mux"
 
 	"github.com/PacketFire/paste-click/lib/objectstore"
 	"github.com/PacketFire/paste-click/lib/objectstore/drivers/mock"
@@ -14,6 +15,10 @@ import (
 
 var (
 	testObject = objectstore.New(
+		"text/html",
+		[]byte("hello"),
+	)
+	returnedTestObject = objectstore.New(
 		"text/plain",
 		[]byte("hello"),
 	)

--- a/handlers/upload/handler.go
+++ b/handlers/upload/handler.go
@@ -71,5 +71,11 @@ func getMimeString(data []byte) (string, error) {
 	if err != nil {
 		log.Fatalf("error occured during type lookup: %v", err)
 	}
+
+	// DEVNOTE NC hotfix for #56
+	if mimetype == `text/html` {
+		mimetype = `text/plain`
+	}
+
 	return mimetype, nil
 }


### PR DESCRIPTION
# Introduction
This PR includes a tiny hotfix to rewrite `text/html` -> `text/plain`. I've included an example manual test below showing that it works.

```
echo 'world' | curl -sv 'http://localhost:8001/' -H 'content-type: text/html' -H 'Host: paste.click' --data-binary @-
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8001 (#0)
> POST / HTTP/1.1
> Host: paste.click
> User-Agent: curl/7.54.0
> Accept: */*
> content-type: text/html
> Content-Length: 6
>
* upload completely sent off: 6 out of 6 bytes
< HTTP/1.1 200 OK
< Date: Tue, 26 Feb 2019 14:30:54 GMT
< Content-Length: 45
< Content-Type: text/plain; charset=utf-8
<
http://localhost:8080/WReFt5RgHiErJg4lklY2_Q
* Connection #0 to host localhost left intact
```

```
curl -sD - 'http://localhost:8001/WReFt5RgHiErJg4lklY2_Q' -H 'Host: paste.click'
HTTP/1.1 200 OK
Content-Type: text/plain
Pc-Mime-Type: text/plain
Pc-Object: WReFt5RgHiErJg4lklY2_Q
Pc-Size:
Pc-Uploaded: 2019-02-26 14:30:54.5903185 +0000 UTC m=+714.005086701
Date: Tue, 26 Feb 2019 14:31:35 GMT
Content-Length: 6

world
```

It's worth noting that this is _ONLY_ a hotfix and that we should address a more permanent solution to rewrite rules for sanitizing metadata down the line.

# Dependencies
#56 
# TODO

# Review
- [x] Tested
---
- [x] Ready to Review
- [x] Ready to Merge
